### PR TITLE
Fixing debug error which occurs when currency not set

### DIFF
--- a/includes/gateways/class-dibs-invoice.php
+++ b/includes/gateways/class-dibs-invoice.php
@@ -94,6 +94,8 @@ class WC_Gateway_Dibs_Invoice extends WC_Gateway_Dibs_Factory {
 				break;
 			default:
 				$this->dibs_country = '';
+				$dibs_language = '';
+				break;
 		}
 
 		// Apply filters for language


### PR DESCRIPTION
As soon as I installed the plugin, it triggered an error in the `domain.com/wp-admin/admin.php?page=wc-settings&tab=products` page. This pull request removes that error.

I suspect it should default to a specific language, but it's also not defaulting to a specific country, so I've just left it blank like that.