### PR TITLE
Fix PHP notices and deprecated filters usage

### DIFF
--- a/includes/class-dibs-masterpass-functions.php
+++ b/includes/class-dibs-masterpass-functions.php
@@ -232,7 +232,7 @@ class WC_Gateway_Dibs_MasterPass_Functions {
 	 */
 	function cancel_transaction( $order_id ) {
 		$order = wc_get_order( $order_id );
-		$order_payment_method = $order->payment_method;
+		$order_payment_method = $order->get_payment_method();
 
 		// Do nothing if order's payment method doesn't allow automatic cancellation via DIBS
 		$payment_method_option_name = 'woocommerce_' . $order_payment_method . '_settings';
@@ -259,7 +259,7 @@ class WC_Gateway_Dibs_MasterPass_Functions {
 		}
 
 		// Make sure the order wasn't already cancelled
-		if ( 'yes' == get_post_meta( $order->id, '_dibs_order_cancelled', true ) ){
+		if ( 'yes' == get_post_meta( $order->get_id(), '_dibs_order_cancelled', true ) ){
 			return;
 		}
 
@@ -293,7 +293,7 @@ class WC_Gateway_Dibs_MasterPass_Functions {
 					'dibs-for-woocommerce'
 				)
 			);
-			update_post_meta( $order->id, '_dibs_order_cancelled', 'yes' );
+			update_post_meta( $order->get_id(), '_dibs_order_cancelled', 'yes' );
 
 			return true;
 		} else if ( $response['status'] == 'DECLINED' ) {

--- a/includes/class-wc-dibs-manual-modification.php
+++ b/includes/class-wc-dibs-manual-modification.php
@@ -35,7 +35,7 @@ class WC_Dibs_Manual_Modification {
 		$order = wc_get_order( $post->ID );
 
 		// Only display the metabox if DIBS is the used payment gateway
-		if ( $order->payment_method != 'dibs' ) {
+		if ( $order->get_payment_method() != 'dibs' ) {
 			return;
 		}
 

--- a/includes/gateways/class-dibs-cc.php
+++ b/includes/gateways/class-dibs-cc.php
@@ -406,7 +406,7 @@ class WC_Gateway_Dibs_CC extends WC_Gateway_Dibs_Factory {
 			$args['decorator'] = $this->decorator;
 		}
 
-		$args['ordertext'] = 'Name: ' . $order->billing_first_name . ' ' . $order->billing_last_name . '. Address: ' . $order->billing_address_1 . ', ' . $order->billing_postcode . ' ' . $order->billing_city;
+		$args['ordertext'] = 'Name: ' . $order->get_billing_first_name() . ' ' . $order->get_billing_last_name() . '. Address: ' . $order->get_billing_address_1() . ', ' . $order->get_billing_postcode() . ' ' . $order->get_billing_city();
 
 		// Callback URL doesn't work as in the other gateways. DIBS erase everything
 		// after a '?' in a specified callback URL

--- a/includes/gateways/class-dibs-invoice.php
+++ b/includes/gateways/class-dibs-invoice.php
@@ -94,6 +94,7 @@ class WC_Gateway_Dibs_Invoice extends WC_Gateway_Dibs_Factory {
 				break;
 			default:
 				$this->dibs_country = '';
+				$dibs_language = '';
 		}
 
 		// Apply filters for language
@@ -496,7 +497,7 @@ class WC_Gateway_Dibs_Invoice extends WC_Gateway_Dibs_Factory {
 			$args['decorator'] = $this->decorator;
 		}
 
-		$args['ordertext'] = 'Name: ' . $order->billing_first_name . ' ' . $order->billing_last_name . '. Address: ' . $order->billing_address_1 . ', ' . $order->billing_postcode . ' ' . $order->billing_city;
+		$args['ordertext'] = 'Name: ' . $order->get_billing_first_name() . ' ' . $order->get_billing_last_name() . '. Address: ' . $order->get_billing_address_1() . ', ' . $order->get_billing_postcode() . ' ' . $order->get_billing_city();
 
 		// Callback URL doesn't work as in the other gateways. DIBS erase everything
 		// after a '?' in a specified callback URL

--- a/includes/gateways/class-dibs-masterpass.php
+++ b/includes/gateways/class-dibs-masterpass.php
@@ -68,8 +68,8 @@ class WC_Gateway_Dibs_MasterPass_New extends WC_Gateway_Dibs_Factory {
 		
 		// Address info from MasterPass
 		add_filter( 'woocommerce_form_field_args' , array( $this, 'override_checkout_fields' ), 10, 3  );
-		add_filter( 'default_checkout_country', array( $this, 'maybe_change_default_checkout_country' ) );
-		add_filter( 'default_checkout_postcode', array( $this, 'maybe_change_default_checkout_postcode' ) );
+		add_filter( 'default_checkout_billing_country', array( $this, 'maybe_change_default_checkout_billing_country' ) );
+		add_filter( 'default_checkout_billing_postcode', array( $this, 'maybe_change_default_checkout_billing_postcode' ) );
 		
 		add_action( 'woocommerce_receipt_dibs_masterpass', array( $this, 'receipt_page' ) );
 		add_filter( 'woocommerce_available_payment_gateways', array( $this, 'filter_gateways' ), 1);
@@ -129,7 +129,7 @@ class WC_Gateway_Dibs_MasterPass_New extends WC_Gateway_Dibs_Factory {
 	 *
 	 *
 	 */
-	function maybe_change_default_checkout_country( $country ){
+	function maybe_change_default_checkout_billing_country( $country ){
 		
 		if( true == WC()->session->get( 'dibs_wallet_mp_validate_respons' ) && !( is_user_logged_in() ) ) {
 			$mp_validate_respons = WC()->session->get( 'dibs_wallet_mp_validate_respons' ) ;
@@ -148,7 +148,7 @@ class WC_Gateway_Dibs_MasterPass_New extends WC_Gateway_Dibs_Factory {
 	 *
 	 *
 	 */
-	function maybe_change_default_checkout_postcode( $postcode ){
+	function maybe_change_default_checkout_billing_postcode( $postcode ){
 
 		if( true == WC()->session->get( 'dibs_wallet_mp_validate_respons' ) && !( is_user_logged_in() ) ) {
 			$mp_validate_respons = WC()->session->get( 'dibs_wallet_mp_validate_respons' ) ;
@@ -1141,7 +1141,7 @@ class WC_Gateway_Dibs_MasterPass_New extends WC_Gateway_Dibs_Factory {
 		$data = array(
 			'merchantId'      				=> $this->merchant_id,
 			'amount'      					=> $order->order_total * 100,
-			'clientIp'      				=> get_post_meta( $order->id, '_customer_ip_address', true ),
+			'clientIp'      				=> get_post_meta( $order->get_id(), '_customer_ip_address', true ),
 			'walletSessionId'				=> WC()->session->get( 'dibs_wallet_session_id' ),
 			'orderId'						=> ltrim( $order->get_order_number(), '#')
 		);
@@ -1293,7 +1293,7 @@ class WC_Gateway_Dibs_MasterPass_New extends WC_Gateway_Dibs_Factory {
 			$data = array(
 				'merchantId'      				=> $this->merchant_id,
 				'amount'      					=> $order->order_total * 100,
-				'clientIp'      				=> get_post_meta( $order->id, '_customer_ip_address', true ),
+				'clientIp'      				=> get_post_meta( $order->get_id(), '_customer_ip_address', true ),
 				'walletSessionId'				=> WC()->session->get( 'dibs_wallet_session_id' ),
 				'orderId'						=> ltrim( $order->get_order_number(), '#')
 			);

--- a/includes/gateways/class-dibs-mobilepay.php
+++ b/includes/gateways/class-dibs-mobilepay.php
@@ -346,7 +346,7 @@ class WC_Gateway_Dibs_MobilePay extends WC_Gateway_Dibs_Factory {
 			$args['decorator'] = $this->decorator;
 		}
 
-		$args['ordertext'] = 'Name: ' . $order->billing_first_name . ' ' . $order->billing_last_name . '. Address: ' . $order->billing_address_1 . ', ' . $order->billing_postcode . ' ' . $order->billing_city;
+		$args['ordertext'] = 'Name: ' . $order->get_billing_first_name() . ' ' . $order->get_billing_last_name() . '. Address: ' . $order->get_billing_address_1() . ', ' . $order->get_billing_postcode() . ' ' . $order->get_billing_city();
 
 		// Callback URL doesn't work as in the other gateways. DIBS erase everything
 		// after a '?' in a specified callback URL


### PR DESCRIPTION
PHP: 7.0.19
WooCommerce: 3.1.1
WP_DEBUG on

- Fix PHP Notice: Order properties should not be accessed directly.
- Fix deprecated filters usage on checkout.

fixes #17 
fixes #15 